### PR TITLE
Buncha touchups to add features

### DIFF
--- a/Domain/RandomDice.cs
+++ b/Domain/RandomDice.cs
@@ -28,7 +28,9 @@ namespace RollGen.Domain
 
             foreach (var match in matches)
             {
-                roll = roll.Replace(match.ToString(), $"({string.Join(" + ", GetRoll(match.ToString()))})");
+                var m = match.ToString();
+                int i = roll.IndexOf(m);
+                roll = $"{roll.Substring(0, i)}({string.Join(" + ", GetRoll(m))}){roll.Substring(i+m.Length)}";
             }
             return roll;
         }

--- a/Domain/RandomDice.cs
+++ b/Domain/RandomDice.cs
@@ -40,9 +40,9 @@ namespace RollGen.Domain
         private IEnumerable<int> GetRoll(string roll)
         {
             var sections = roll.Split('d');
-            var quantity_string = sections[0].Trim();
+            var quantity_string = sections[0];
             var quantity = quantity_string.Length == 0 ? 1 : Convert.ToInt32(quantity_string);
-            var die = Convert.ToInt32(sections[1].Trim());
+            var die = Convert.ToInt32(sections[1]);
 
             return Roll(quantity).multi_d(die);
         }

--- a/Domain/RandomDice.cs
+++ b/Domain/RandomDice.cs
@@ -33,7 +33,7 @@ namespace RollGen.Domain
             return roll;
         }
 
-        public override int Compiled(string rolled) => Convert.ToInt32(Parser.GetParser().Compile(rolled).EvalValue(null));
+        public override object CompiledObj(string rolled) => Parser.GetParser().Compile(rolled).EvalValue(null);
 
         private int GetRoll(string roll)
         {

--- a/Domain/RandomDice.cs
+++ b/Domain/RandomDice.cs
@@ -16,12 +16,12 @@ namespace RollGen.Domain
             rollRegex = new Regex("\\d+d\\d+");
         }
 
-        public PartialRoll Roll(int quantity = 1)
+        public override PartialRoll Roll(int quantity = 1)
         {
             return new RandomPartialRoll(quantity, random);
         }
 
-        public int Roll(string roll)
+        public override string RolledString(string roll)
         {
             var matches = rollRegex.Matches(roll);
 
@@ -30,10 +30,10 @@ namespace RollGen.Domain
                 var result = GetRoll(match.ToString());
                 roll = roll.Replace(match.ToString(), result.ToString());
             }
-
-            var rawValue = Parser.GetParser().Compile(roll).EvalValue(null);
-            return Convert.ToInt32(rawValue);
+            return roll;
         }
+
+        public override int Compiled(string rolled) => Convert.ToInt32(Parser.GetParser().Compile(rolled).EvalValue(null));
 
         private int GetRoll(string roll)
         {

--- a/Domain/RandomDice.cs
+++ b/Domain/RandomDice.cs
@@ -1,5 +1,6 @@
 ﻿using Albatross.Expression;
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace RollGen.Domain
@@ -13,7 +14,7 @@ namespace RollGen.Domain
         {
             this.random = random;
 
-            rollRegex = new Regex("\\d+d\\d+");
+            rollRegex = new Regex("\\d* *d *\\d+");
         }
 
         public override PartialRoll Roll(int quantity = 1)
@@ -27,21 +28,21 @@ namespace RollGen.Domain
 
             foreach (var match in matches)
             {
-                var result = GetRoll(match.ToString());
-                roll = roll.Replace(match.ToString(), result.ToString());
+                roll = roll.Replace(match.ToString(), $"({string.Join(" + ", GetRoll(match.ToString()))})");
             }
             return roll;
         }
 
         public override object CompiledObj(string rolled) => Parser.GetParser().Compile(rolled).EvalValue(null);
 
-        private int GetRoll(string roll)
+        private IEnumerable<int> GetRoll(string roll)
         {
             var sections = roll.Split('d');
-            var quantity = Convert.ToInt32(sections[0]);
-            var die = Convert.ToInt32(sections[1]);
+            var quantity_string = sections[0].Trim();
+            var quantity = quantity_string.Length == 0 ? 1 : Convert.ToInt32(quantity_string);
+            var die = Convert.ToInt32(sections[1].Trim());
 
-            return Roll(quantity).d(die);
+            return Roll(quantity).multi_d(die);
         }
     }
 }

--- a/Domain/RandomPartialRoll.cs
+++ b/Domain/RandomPartialRoll.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace RollGen.Domain
 {
@@ -13,14 +14,10 @@ namespace RollGen.Domain
             this.random = random;
         }
 
-        public int d(int die)
+        public override IEnumerable<int> multi_d(int die)
         {
-            var roll = 0;
-
             while (quantity-- > 0)
-                roll += random.Next(die) + 1;
-
-            return roll;
+                yield return random.Next(die) + 1;
         }
     }
 }

--- a/Domain/RandomPartialRoll.cs
+++ b/Domain/RandomPartialRoll.cs
@@ -13,51 +13,6 @@ namespace RollGen.Domain
             this.random = random;
         }
 
-        public int d2()
-        {
-            return d(2);
-        }
-
-        public int d3()
-        {
-            return d(3);
-        }
-
-        public int d4()
-        {
-            return d(4);
-        }
-
-        public int d6()
-        {
-            return d(6);
-        }
-
-        public int d8()
-        {
-            return d(8);
-        }
-
-        public int d10()
-        {
-            return d(10);
-        }
-
-        public int d12()
-        {
-            return d(12);
-        }
-
-        public int d20()
-        {
-            return d(20);
-        }
-
-        public int Percentile()
-        {
-            return d(100);
-        }
-
         public int d(int die)
         {
             var roll = 0;

--- a/RollGen/Dice.cs
+++ b/RollGen/Dice.cs
@@ -4,7 +4,8 @@
     {
         public abstract PartialRoll Roll(int quantity = 1);
         public abstract string RolledString(string roll);
-        public abstract int Compiled(string rolled);
+        public abstract object CompiledObj(string rolled);
+        public int Compiled(string rolled) => System.Convert.ToInt32(CompiledObj(rolled));
         public int Roll(string roll) => Compiled(RolledString(roll));
     }
 }

--- a/RollGen/Dice.cs
+++ b/RollGen/Dice.cs
@@ -1,8 +1,10 @@
 ﻿namespace RollGen
 {
-    public interface Dice
+    public abstract class Dice
     {
-        PartialRoll Roll(int quantity = 1);
-        int Roll(string roll);
+        public abstract PartialRoll Roll(int quantity = 1);
+        public abstract string RolledString(string roll);
+        public abstract int Compiled(string rolled);
+        public int Roll(string roll) => Compiled(RolledString(roll));
     }
 }

--- a/RollGen/Dice.cs
+++ b/RollGen/Dice.cs
@@ -6,6 +6,7 @@
         public abstract string RolledString(string roll);
         public abstract object CompiledObj(string rolled);
         public int Compiled(string rolled) => System.Convert.ToInt32(CompiledObj(rolled));
+        public T Compiled<T>(string rolled) => (T)System.Convert.ChangeType(CompiledObj(rolled), typeof(T));
         public int Roll(string roll) => Compiled(RolledString(roll));
     }
 }

--- a/RollGen/PartialRoll.cs
+++ b/RollGen/PartialRoll.cs
@@ -1,16 +1,16 @@
 ﻿namespace RollGen
 {
-    public interface PartialRoll
+    public abstract class PartialRoll
     {
-        int d2();
-        int d3();
-        int d4();
-        int d6();
-        int d8();
-        int d10();
-        int d12();
-        int d20();
-        int Percentile();
-        int d(int die);
+        public int d2() => d(2);
+        public int d3() => d(3);
+        public int d4() => d(4);
+        public int d6() => d(6);
+        public int d8() => d(8);
+        public int d10() => d(10);
+        public int d12() => d(12);
+        public int d20() => d(20);
+        public int Percentile() => d(100);
+        public abstract int d(int die);
     }
 }

--- a/RollGen/PartialRoll.cs
+++ b/RollGen/PartialRoll.cs
@@ -1,4 +1,7 @@
-﻿namespace RollGen
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace RollGen
 {
     public abstract class PartialRoll
     {
@@ -11,6 +14,7 @@
         public int d12() => d(12);
         public int d20() => d(20);
         public int Percentile() => d(100);
-        public abstract int d(int die);
+        public int d(int die) => multi_d(die).Sum();
+        public abstract IEnumerable<int> multi_d(int die);
     }
 }

--- a/Tests/Unit/DiceTests.cs
+++ b/Tests/Unit/DiceTests.cs
@@ -100,5 +100,16 @@ namespace RollGen.Test.Unit
             mockRandom.Verify(r => r.Next(90210), Times.Exactly(9266));
             mockRandom.Verify(r => r.Next(600), Times.Exactly(42));
         }
+
+        [Test]
+        public void RollMultipleSameRollString()
+        {
+            var count = 0;
+            mockRandom.Setup(r => r.Next(629)).Returns(() => count++);
+
+            var roll = dice.RolledString("7d629%7d629").Split('%');
+            Assert.That(!roll[0].Equals(roll[1]));
+            mockRandom.Verify(r => r.Next(629), Times.Exactly(14));
+        }
     }
 }

--- a/Tests/Unit/DiceTests.cs
+++ b/Tests/Unit/DiceTests.cs
@@ -67,6 +67,26 @@ namespace RollGen.Test.Unit
         }
 
         [Test]
+        public void RollFromStringSpaces()
+        {
+            var count = 0;
+            mockRandom.Setup(r => r.Next(90210)).Returns(() => count++);
+
+            var roll = dice.Roll("  9266    d  90210   ");
+            Assert.That(roll, Is.EqualTo(42934011));
+            mockRandom.Verify(r => r.Next(90210), Times.Exactly(9266));
+        }
+
+        [Test]
+        public void RollFromStringNoQuantity()
+        {
+            mockRandom.Setup(r => r.Next(90210)).Returns(629);
+
+            Assert.That(dice.Roll("d90210"), Is.EqualTo(dice.Roll("1d90210")));
+            mockRandom.Verify(r => r.Next(90210), Times.Exactly(2));
+        }
+
+        [Test]
         public void RollFromStringWithBonus()
         {
             var count = 0;


### PR DESCRIPTION
Ignore spaces in parsing d strings
Allow dice expressions to be returned without loss of precision (not just as ints)
Allow returning a string of the pre-calculation, post-rolling expression, so the user can know what the results were before the math.

Also Fix a bug in which the result of the first roll of a dice expression would replace all of that expression in the string.
For example
`3d3+4+5d5+3d3`
could become
`(1 + 2 +  2)+4+(2 + 5 + 4 + 1 + 1)+(1 + 2 + 2)`
but will now become
`(1 + 2 + 2)+4+(2 + 5 + 4 + 1 + 1)+(1 + 3 + 3)`
Note that this bug is fixed in the last commit, but I believe if you'd prefer to just have this fix you can cherry pick it cleanly.
