### PR TITLE
Move useful utility functions out into their own static class

### DIFF
--- a/RollGen.Domain/DomainDice.cs
+++ b/RollGen.Domain/DomainDice.cs
@@ -49,7 +49,7 @@ namespace RollGen.Domain
                 var lenientReplacedDice = ReplaceDiceExpression(matchGroupValue, true);
                 var unevaluatedMatch = Evaluate(lenientReplacedDice);
                 var target = expressionOpen + matchGroupValue + expressionClose;
-                var replacement = BooleanOrType<T>(unevaluatedMatch).ToString();
+                var replacement = Utils.BooleanOrType<T>(unevaluatedMatch).ToString();
 
                 source = ReplaceFirst(source, target, replacement);
             }
@@ -82,24 +82,7 @@ namespace RollGen.Domain
         public T Evaluate<T>(string expression)
         {
             var evaluation = Evaluate(expression);
-            return ChangeType<T>(evaluation);
-        }
-
-        public T ChangeType<T>(object rawEvaluatedExpression)
-        {
-            if (rawEvaluatedExpression is T)
-                return (T)rawEvaluatedExpression;
-
-            return (T)Convert.ChangeType(rawEvaluatedExpression, typeof(T));
-        }
-
-        /// <summary>Returns a string of the provided object as boolean, if it is one, otherwise of Type T.</summary>
-        public string BooleanOrType<T>(object rawEvaluatedExpression)
-        {
-            if (rawEvaluatedExpression is bool)
-                return rawEvaluatedExpression.ToString();
-
-            return ChangeType<T>(rawEvaluatedExpression).ToString();
+            return Utils.ChangeType<T>(evaluation);
         }
 
         public string ReplaceRollsWithSum(string expression)

--- a/RollGen.Tests.Integration.Stress/ExpressionTests.cs
+++ b/RollGen.Tests.Integration.Stress/ExpressionTests.cs
@@ -83,6 +83,33 @@ namespace RollGen.Tests.Integration.Stress
             Assert.That(rolls.Count, Is.EqualTo(expectedCount));
         }
 
+        [TestCase("1d20 > 10", true, false)]
+        [TestCase("1d20 < 2d10", true, false)]
+        [TestCase("3d2 >= 2d3", true, false)]
+        [TestCase("2d6 <= 3d4", true, false)]
+        [TestCase("1d2 = 2", true, false)]
+        [TestCase("1d100 > 0", true)]
+        [TestCase("100 < 1d20", false)]
+        [TestCase("1d1 = 1", true)]
+        [TestCase("9266 = 9266", true)]
+        [TestCase("9266 = 90210", false)]
+        [TestCase("1d2 = 3", false)]
+        public void FullRangeTruth(string expression, params bool[] expectedRolls)
+        {
+            var rolls = Populate(new HashSet<bool>(), () => GenerateBoolean(expression), expectedRolls.Length);
+
+            Assert.That(rolls, Is.EquivalentTo(expectedRolls));
+            Assert.That(expectedRolls, Is.EquivalentTo(rolls));
+        }
+
+        private bool GenerateBoolean(string expression)
+        {
+            var totaledExpression = Dice.ReplaceExpressionWithTotal(expression);
+            var evaluatedExpression = Dice.Evaluate<bool>(totaledExpression);
+
+            return evaluatedExpression;
+        }
+
         [TestCase("1d2*3d4", 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24)]
         [TestCase("2d3*4", 8, 12, 16, 20, 24)]
         [TestCase("1d3*5", 5, 10, 15)]

--- a/RollGen.Tests.Integration.Stress/StressTests.cs
+++ b/RollGen.Tests.Integration.Stress/StressTests.cs
@@ -80,7 +80,7 @@ namespace RollGen.Tests.Integration.Stress
                 Assert.Fail("Something took way too long");
         }
 
-        protected IEnumerable<int> Populate(ICollection<int> target, Func<int> generate, int expectedTotal)
+        protected IEnumerable<T> Populate<T>(ICollection<T> target, Func<T> generate, int expectedTotal)
         {
             do
             {

--- a/RollGen.Tests.Unit/RollGen.Tests.Unit.csproj
+++ b/RollGen.Tests.Unit/RollGen.Tests.Unit.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PartialRolls\d3Tests.cs" />
     <Compile Include="PartialRolls\dTests.cs" />
     <Compile Include="RandomPartialRollFactoryTests.cs" />
+    <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RollGen.Domain\RollGen.Domain.csproj">

--- a/RollGen.Tests.Unit/UtilsTests.cs
+++ b/RollGen.Tests.Unit/UtilsTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace RollGen.Tests.Unit
+{
+    [TestFixture]
+    class UtilsTests
+    {
+        // Work around NUnit not supporting Generics, by using this function.
+        object GenericTester(string function_name, Type T, object[] parameters)
+            => typeof(Utils).GetMethod(function_name).MakeGenericMethod(T).Invoke(null, parameters);
+
+        [TestCase(typeof(double), 8)]
+        [TestCase(typeof(int), true)]
+        [TestCase(typeof(string), 8)]
+        public void ChangeType(Type T, object arg)
+        {
+            var result = GenericTester("ChangeType", T, new[] { arg });
+            Assert.That(result, Is.TypeOf(T));
+        }
+
+        [TestCase(typeof(string), "true", "true")]
+        [TestCase(typeof(double), true, "True")]
+        [TestCase(typeof(string), false, "False")]
+        [TestCase(typeof(float), 0.8f, "0.8")]
+        [TestCase(typeof(int), 0.8f, "1")]
+        [TestCase(typeof(int), 0.3f, "0")]
+        public void BooleanOrType(Type T, object arg, string expected)
+        {
+            var result = GenericTester("BooleanOrType", T, new[] { arg });
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/RollGen/RollGen.csproj
+++ b/RollGen/RollGen.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Limits.cs" />
     <Compile Include="PartialRoll.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RollGen/Utils.cs
+++ b/RollGen/Utils.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace RollGen
+{
+    public static class Utils
+    {
+        public static T ChangeType<T>(object rawEvaluatedExpression)
+        {
+            if (rawEvaluatedExpression is T)
+                return (T)rawEvaluatedExpression;
+
+            return (T)Convert.ChangeType(rawEvaluatedExpression, typeof(T));
+        }
+
+        /// <summary>Returns a string of the provided object as boolean, if it is one, otherwise of Type T.</summary>
+        public static string BooleanOrType<T>(object rawEvaluatedExpression)
+        {
+            if (rawEvaluatedExpression is bool)
+                return rawEvaluatedExpression.ToString();
+
+            return ChangeType<T>(rawEvaluatedExpression).ToString();
+        }
+    }
+}


### PR DESCRIPTION
DomainDice.ChangeType<T> => Utils.ChangeType<T>
DomainDice.BooleanOrType<T> => Utils.BooleanOrType<T>
Adds Utils.cs to RollGen project.

Sorry, I forgot to make this earlier.
